### PR TITLE
Add Author to alerts.

### DIFF
--- a/core/codechecker.py
+++ b/core/codechecker.py
@@ -38,12 +38,13 @@ class CodeChecker:
 
 
 class Alert:
-    def __init__(self, rule, filename, repo, commit, line):
+    def __init__(self, rule, filename, repo, commit, line, author):
         self.rule = rule
         self.filename = filename
         self.repo = repo
         self.commit = commit
         self.line = line
+        self.author = author
 
 
 class Rule:

--- a/repominer.py
+++ b/repominer.py
@@ -13,7 +13,7 @@ from core.ruleparser import load_rules, build_resolved_ruleset
 def check_alerts_in_file(code_checker, file, filename):
     content = file.readlines()
     result = code_checker.check(content, filename)
-    actual_alerts = [Alert(rule, filename, '', '', line) for rule, line in result]
+    actual_alerts = [Alert(rule, filename, '', '', line, None) for rule, line in result]
     return actual_alerts
 
 parser = argparse.ArgumentParser(description='Check a sourcecode repo')

--- a/tests/test_repoguard.py
+++ b/tests/test_repoguard.py
@@ -54,9 +54,9 @@ class AlertSubscriptionTestCase(BaseTestCase):
         rule1 = Rule("xxe::test", Mock(), {'description': 'descr1'})
         rule2 = Rule("xxe::simple", Mock(), {'description': 'descr2'})
         self.rg.check_results = [
-            Alert(rule1, "file", "repo", "1231commit", "line1"),
-            Alert(rule2, "file", "repo", "1231commit", "line1"),
-            Alert(rule1, "file", "repo", "1231commit", "line1")
+            Alert(rule1, "file", "repo", "1231commit", "line1", "author1"),
+            Alert(rule2, "file", "repo", "1231commit", "line1", "author2"),
+            Alert(rule1, "file", "repo", "1231commit", "line1", "author1")
         ]
         mock_notification = Mock()
         mocks[0].return_value = mock_notification


### PR DESCRIPTION
Commit message is self-explanatory - we thought it might be useful to store the commit author as part of the alerts.
